### PR TITLE
Add image_url support in chat messages

### DIFF
--- a/src/Models/ChatMessage.php
+++ b/src/Models/ChatMessage.php
@@ -31,9 +31,9 @@ class ChatMessage
      *
      * @return ChatMessage
      */
-    public static function from(ChatRole $role, mixed $content, string|array|null $name = null, ?ChatFunctionCall $functionCall = null): ChatMessage
+    public static function from(ChatRole $role, mixed $content, string|array|null $name = null, ?ChatFunctionCall $functionCall = null, ?string $image_url = null): ChatMessage
     {
-        return new static($role, $name, $content, $functionCall);
+        return new static($role, $name, $content, $functionCall, $image_url);
     }
 
     /**

--- a/src/Models/ChatMessage.php
+++ b/src/Models/ChatMessage.php
@@ -13,12 +13,14 @@ class ChatMessage
      * @param string|null $name
      * @param mixed|null $content
      * @param ChatFunctionCall|null $functionCall
+     * @param string|null $image_url
      */
     public function __construct(
         public readonly ChatRole $role,
         public readonly ?string $name = null,
         public readonly mixed $content = null,
-        public readonly ?ChatFunctionCall $functionCall = null
+        public readonly ?ChatFunctionCall $functionCall = null,
+        public readonly ?string $image_url = null,
     ) {}
 
     /**
@@ -55,8 +57,20 @@ class ChatMessage
     {
         $message = [
             'role' => $this->role->value,
-            'content' => is_string($this->content) ? $this->content : json_encode($this->content),
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => is_string($this->content) ? $this->content : json_encode($this->content),
+                ],
+            ],
         ];
+        
+        if (isset($this->image_url) && is_string($this->image_url)) {
+            $message['content'][] = [
+                'type' => 'image_url',
+                'image_url' => ['url' => $this->image_url],
+            ];
+        }
 
         if ($this->name) {
             $message['name'] = $this->name;


### PR DESCRIPTION
This simple change allows you to also send images to the ChatGPT API. Example usage:

```php
use App\GPT\Chats\Motor\MotorGPTChat; // replace with your GPTChat
use MalteKuhr\LaravelGPT\Enums\ChatRole;
use MalteKuhr\LaravelGPT\Models\ChatMessage;

$chat = MotorGPTChat::make();
$chat->addMessage(
    ChatMessage::from(
        role: ChatRole::USER,
        content: 'What kind of motorcycle is this?',
        image_url: 'https://www.lorddrakekustoms.com/wp-content/uploads/2024/08/geico-scrambler-manillar.jpg',
    )
);
echo $chat->send();

```